### PR TITLE
FIX vue router with express

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -55,6 +55,11 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "main": "server.js",
   "dependencies": {
+    "connect-history-api-fallback": "^1.6.0",
     "core-js": "^3.6.5",
     "express": "^4.17.1",
     "pg": "^8.7.1",

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const express = require("express");
+var history = require('connect-history-api-fallback');
 
 const app = express()
 
@@ -23,10 +24,24 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // bind static front
-app.use(express.static('../frontend/dist'))
+const staticFileMiddleware = express.static('../frontend/dist')
+
+app.use(staticFileMiddleware)
+app.use(history({
+    rewrites: [
+        {
+            from: /^\/api\/.*$/,
+            to: function (context) {
+                return context.parsedUrl.path // if the url matches "/api/" (https://regexr.com/) it is not for Vue
+            }
+        }
+    ]
+}))
+app.use(staticFileMiddleware)
+// ^ `app.use(staticFileMiddleware)` is included twice as per https://github.com/bripkens/connect-history-api-fallback/blob/master/examples/static-files-and-index-rewrite/README.md#configuring-the-middleware
 
 // simple route
-app.get("/hello", (req, res) => {
+app.get("/api/hello", (req, res) => {
     res.statusCode = 200;
     res.json({
         status: 200,


### PR DESCRIPTION
### Contexte
`vue router` ne peut pas fonctionner après être build (les routes sont gérés par le backend et Vue est un "single-page").
En appelant des routes telles que `/jeu` on tombe donc sur du 404 vu que le back ne connait pas cette route, et la route ne peut pas être gérée depuis le static

### Solution
Plusieurs [solutions sont possibles](https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations), j'ai choisi d'utiliser [celle-ci](https://github.com/bripkens/connect-history-api-fallback). Elle permet d'ajouter dans le `server.js` un middleware qui va rediriger vers le `index.html` (et donc vers Vue qui pourra faire ses gestions de single-page) et qui ne fait rien si jamais l'url commence par `/api/`.